### PR TITLE
ビューから検索するときに `INVALID_FUCTION_ARGUMENT` エラーが発生しないように修正する

### DIFF
--- a/template/ddl_create_view.hql.j2
+++ b/template/ddl_create_view.hql.j2
@@ -12,5 +12,6 @@ SELECT
   {%- endfor %}
 FROM
   {{table_name}}
-WHERE (("identity_timeinterval" IS NOT NULL) AND ("identity_timeinterval" <> ''))
+WHERE
+  "$path" NOT LIKE '%.json'
 ;


### PR DESCRIPTION
## 背景
- CURの出力データにManifest.jsonが含まれるようになった
- その影響でビューから検索すると実行時エラーが発生するようになっていた
    - 空文字列に対して `from_iso8601_timestamp` などの関数を適用した場合に発生する

## 修正内容
- [x] スキャン対象からJSONファイルを除外する